### PR TITLE
Add Linux support via Proton

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ To build and run GGPOPLUSR:
 3. At CMake configure step, point the vcredist_86_exe variable to the Microsoft Visual C++ Redistributable for Visual Studio 2015, 2017 and 2019 installer program for x86 (vcredist.x86.exe). If you cannot locate it in your Visual Studio installation folder, you can [get it from Microsoft](https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads).
 4. Open the solution in Visual Studio and build the PACKAGE project to generate the installer.
 
+# Running on Linux
+As of right now, there is no way to compile GGPOPLUSR on Linux, so in order to run it you will need to compile it yourself on Windows first or download a release. The Debug target will not run in Linux.
+Once you have this, there are two ways to  run it.
+ * Run Steam through Wine
+Once you have an instance of Steam running through Wine, you just need to run Launcher.exe in the same prefix.
+ * Use Proton
+Change the GGPOPLUSR_DIR variable in ggpoplusr.sh to the location of your compiled GGPOPLUSR build, place it in your +R install directory, and set the Steam launch options to `./ggpoplusr.sh %command%`.
+
 ## Why GGPO? Why +R? Why now?
 While lockstep netcode was considered industry standard for many years
 (including triple-A titles like _Street Fighter IV_), its failures have

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To build and run GGPOPLUSR:
 3. At CMake configure step, point the vcredist_86_exe variable to the Microsoft Visual C++ Redistributable for Visual Studio 2015, 2017 and 2019 installer program for x86 (vcredist.x86.exe). If you cannot locate it in your Visual Studio installation folder, you can [get it from Microsoft](https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads).
 4. Open the solution in Visual Studio and build the PACKAGE project to generate the installer.
 
-# Running on Linux
+### Running on Linux
 As of right now, there is no way to compile GGPOPLUSR on Linux, so in order to run it you will need to compile it yourself on Windows first or download a release. The Debug target will not run in Linux.
 Once you have this, there are two ways to  run it.
  * Run Steam through Wine

--- a/README.md
+++ b/README.md
@@ -64,9 +64,13 @@ To build and run GGPOPLUSR:
 ### Running on Linux
 As of right now, there is no way to compile GGPOPLUSR on Linux, so in order to run it you will need to compile it yourself on Windows first or download a release. The Debug target will not run in Linux.
 Once you have this, there are two ways to  run it.
+
  * Run Steam through Wine
+
 Once you have an instance of Steam running through Wine, you just need to run Launcher.exe in the same prefix.
+
  * Use Proton
+
 Change the GGPOPLUSR_DIR variable in ggpoplusr.sh to the location of your compiled GGPOPLUSR build, place it in your +R install directory, and set the Steam launch options to `./ggpoplusr.sh %command%`.
 
 ## Why GGPO? Why +R? Why now?

--- a/ggpoplusr.sh
+++ b/ggpoplusr.sh
@@ -1,0 +1,11 @@
+##
+## Place this in the same directory as the +R exe and change your launch settings in Steam to
+## ./ggpoplusr.sh %command%
+##
+
+#set this yourself
+GGPOPLUSR_DIR=
+
+export GGPOPLUSR_LINUX_DIR="$PWD"
+cd "$GGPOPLUSR_DIR"
+"$1" waitforexitandrun Launcher.exe

--- a/src/launcher/launcher.cxx
+++ b/src/launcher/launcher.cxx
@@ -187,11 +187,20 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int nCmdShow
 	char szSidecarConfigPathA[1024] = { 0 };
 	char szSidecarDllPathA[1024] = { 0 };
 
+	DWORD env_size = 0;
+
 	if (Update()) {
 		return 0;
 	}
 
-	FindGuilty(szGuiltyDirectory, szGuiltyExePath);
+	env_size = GetEnvironmentVariableW(L"GGPOPLUSR_LINUX_DIR", szGuiltyDirectory, 1024);
+
+	if (env_size > 0) {
+		PathCombineW(szGuiltyExePath, szGuiltyDirectory, L"GGXXACPR_Win.exe");
+	}
+	else {
+		FindGuilty(szGuiltyDirectory, szGuiltyExePath);
+	}
 	FindSidecar(szSidecarDllPathA);
 	FindConfigFile(szSidecarConfigPathA);
 	CreateAppIDFile(szGuiltyDirectory);


### PR DESCRIPTION
FindGuilty() doesn't work on Linux, since the Steam location registry key doesn't exist in the wine prefix. To get around this, I made the launcher check for the GGPOPLUSR_LINUX_DIR environment variable and use that in place of calling FindGuilty(). I also included a script to automatically run all of this through Steam, and added instructions on how to do all of this to the readme.