### PR TITLE
Created a modified Makefile for M.S. Detours; modified CONFIGURE.PS1.

### DIFF
--- a/CONFIGURE.ps1
+++ b/CONFIGURE.ps1
@@ -76,6 +76,11 @@ if (-not $?) {throw "Failed to build GGPO with Release configuration"}
 
 Write-Host "`nBuild Detours" -ForegroundColor Yellow
 cd $workspace_path\Detours
+
+#move makefile into Detours directory
+Copy-Item $ggpoplusr_filepath\resources\detours_Makefile
+Rename-Item Makefile Makefile.old
+Rename-Item detours_Makefile Makefile
 nmake
 if (-not $?) {throw "Failed to build Detours"}
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ To manually build and run GGPOPLUSR:
      provide custom overlays for new features and debugging. 
    * [JSON for Modern C++](https://github.com/nlohmann/json). JSON for Modern C++
      is used to parse JSON responses from GitHub's REST API.
-2. Build GGPO and Detours using x86-compatible build tools.
+2. Replace the Microsoft's Detours' [Makefile](https://github.com/microsoft/Detours/blob/master/Makefile) with [resources/detours_Makefile](https://github.com/bogedden/GGPOPLUSR/blob/master/detours_Makefile) and rename accordingly.
+3. Build GGPO and Detours using x86-compatible build tools.
    * GGXXAC+R is natively compiled for 32-bit x86, and using an entire 32-bit
      toolchain prevents us from needing to handle cross compilation.
    * GGPO and Detours are large enough that they benefit from precompilation-

--- a/resources/detours_Makefile
+++ b/resources/detours_Makefile
@@ -1,0 +1,43 @@
+##############################################################################
+##
+##  Makefile for Detours.
+##
+##  Microsoft Research Detours Package
+##
+##  Copyright (c) Microsoft Corporation.  All rights reserved.
+##
+
+ROOT = .
+!include "$(ROOT)\system.mak"
+
+all:
+    cd "$(MAKEDIR)"
+	@if exist "$(MAKEDIR)\core\makefile" cd "$(MAKEDIR)\core" && $(MAKE) /NOLOGO /$(MAKEFLAGS)
+    cd "$(MAKEDIR)\src"
+    @$(MAKE) /NOLOGO /$(MAKEFLAGS)
+    cd "$(MAKEDIR)"
+
+clean:
+    cd "$(MAKEDIR)"
+	@if exist "$(MAKEDIR)\core\makefile" cd "$(MAKEDIR)\core" && $(MAKE) /NOLOGO /$(MAKEFLAGS) clean
+    cd "$(MAKEDIR)\src"
+    @$(MAKE) /NOLOGO /$(MAKEFLAGS) clean
+	@if exist "$(MAKEDIR)\bugs\makefile" cd "$(MAKEDIR)\bugs" && $(MAKE) /NOLOGO /$(MAKEFLAGS) clean
+    cd "$(MAKEDIR)"
+
+realclean: clean
+    cd "$(MAKEDIR)"
+	@if exist "$(MAKEDIR)\core\makefile" cd "$(MAKEDIR)\core" && $(MAKE) /NOLOGO /$(MAKEFLAGS) realclean
+    cd "$(MAKEDIR)\src"
+    @$(MAKE) /NOLOGO /$(MAKEFLAGS) realclean
+	@if exist "$(MAKEDIR)\bugs\makefile" cd "$(MAKEDIR)\bugs" && $(MAKE) /NOLOGO /$(MAKEFLAGS) realclean
+    cd "$(MAKEDIR)"
+    -rmdir /q /s $(INCDS) 2> nul
+    -rmdir /q /s $(LIBDS) 2> nul
+    -rmdir /q /s $(BINDS) 2> nul
+    -rmdir /q /s dist 2> nul
+    -del docsrc\detours.chm 2> nul
+    -del /q *.msi 2>nul
+    -del /q /f /s *~ 2>nul
+
+################################################################# End of File.


### PR DESCRIPTION
In order to remove the hidden dependency of the .NET SDK rooted within Microsoft Detours' test files, a modified makefile was created to replace the original. README.MD and CONFIGURE.PS1 were also modified to reflect these changes.